### PR TITLE
Bugfix: subtypesEnabled always set to false in SiteTuner

### DIFF
--- a/src/content_script/content_script.ts
+++ b/src/content_script/content_script.ts
@@ -44,22 +44,23 @@ export function getMainDomainNameUnsafe(host: string): string {
 
 function createCommentTunerForSite(threshold: number,
                                    enabledAttributes: EnabledAttributes,
-                                   theme: ThemeType)
+                                   theme: ThemeType,
+                                   subtypesEnabled: boolean)
 : SiteTuner|null {
   // TODO: does this handle various "short" URLs? I believe at least 'youtu.be'
   // gets redirected to youtube.com, so that works, but check others.
   const domain = getCurrentMainDomainName();
   switch (domain) {
     case 'youtube.com':
-      return new YoutubeTuner(threshold, enabledAttributes, theme);
+      return new YoutubeTuner(threshold, enabledAttributes, theme, subtypesEnabled);
     case 'reddit.com':
-      return new RedditTuner(threshold, enabledAttributes, theme);
+      return new RedditTuner(threshold, enabledAttributes, theme, subtypesEnabled);
     case 'twitter.com':
-      return new TwitterTuner(threshold, enabledAttributes, theme);
+      return new TwitterTuner(threshold, enabledAttributes, theme, subtypesEnabled);
     case 'facebook.com':
-      return new FacebookTuner(threshold, enabledAttributes, theme);
+      return new FacebookTuner(threshold, enabledAttributes, theme, subtypesEnabled);
     case 'disqus.com':
-      return new DisqusTuner(threshold, enabledAttributes, theme);
+      return new DisqusTuner(threshold, enabledAttributes, theme, subtypesEnabled);
     default:
       console.log('site not handled?:', domain);
       return null;
@@ -75,7 +76,7 @@ async function launchCommentTuner() {
   const globalEnabled = await settings.getEnabled();
   const theme = await settings.getTheme();
   const siteTuner: SiteTuner|null = createCommentTunerForSite(
-    threshold, attributes, theme);
+    threshold, attributes, theme, subtypesEnabled);
   // If the site isn't enabled, we don't launch the tuner, but we still inject
   // the content script. This is so that if the site is enabled later, Tune
   // starts working.

--- a/src/content_script/site_tuner.spec.ts
+++ b/src/content_script/site_tuner.spec.ts
@@ -77,7 +77,7 @@ describe('SiteTuner tests', () => {
 
   it('Tuner handles existing comments on launch', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     spyOn(siteTuner, 'handleAddedComment');
     siteTuner.launchTuner();
     expect(siteTuner.handleAddedComment).toHaveBeenCalledTimes(3);

--- a/src/content_script/site_tuner.spec.ts
+++ b/src/content_script/site_tuner.spec.ts
@@ -85,7 +85,7 @@ describe('SiteTuner tests', () => {
 
   xit('Tuner handles added comments', (done) => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
     const commentsContainer =
       document.querySelector('.' + COMMENTS_CONTAINER_CLASS) as HTMLElement;
@@ -117,7 +117,7 @@ describe('SiteTuner tests', () => {
 
   it('Test handleAddedNode correctly handles comment', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
     const testComment = addComment('Foo bar');
 
@@ -128,7 +128,7 @@ describe('SiteTuner tests', () => {
 
   it('Test handleAddedNode ignores elements that are not comments', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
     const testNotAComment = addComment('Foo bar');
     testNotAComment.classList.remove(COMMENT_CLASS);
@@ -140,7 +140,7 @@ describe('SiteTuner tests', () => {
 
   it('Test handleRemovedNode correctly handles comment', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
     const testComment = addComment('Foo bar');
 
@@ -151,7 +151,7 @@ describe('SiteTuner tests', () => {
 
   it('Test handleRemovedNode ignores elements that are not comments', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
     const testNotAComment = addComment('Foo bar');
     testNotAComment.classList.remove(COMMENT_CLASS);
@@ -174,7 +174,7 @@ describe('SiteTuner tests', () => {
     };
     chromeStub.runtime.sendMessage.yields(testScores);
 
-    const siteTuner = new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+    const siteTuner = new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
 
     const testComment = addComment('Hello world!');
@@ -186,7 +186,7 @@ describe('SiteTuner tests', () => {
   });
 
   it('Tests wrapCommentBlock sets correct attributes', () => {
-    const siteTuner = new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+    const siteTuner = new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
 
     const commentText = 'Hello world!';
@@ -201,7 +201,7 @@ describe('SiteTuner tests', () => {
 
   it('Test wrapCommentBlock wraps comment children', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
 
     const commentText = 'Hello world!';
@@ -217,7 +217,7 @@ describe('SiteTuner tests', () => {
 
   it('Test unwrapCommentBlock', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
 
     const commentText = 'Hello world!';
@@ -234,7 +234,7 @@ describe('SiteTuner tests', () => {
 
   it('Test unwrapCommentBlock on not-yet-wrapped block', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
 
     const commentText = 'Hello world!';
@@ -244,7 +244,7 @@ describe('SiteTuner tests', () => {
 
   it('Test handleRemovedComment', () => {
     const siteTuner =
-      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted);
+      new SiteTunerImpl(0.5, DEFAULT_ATTRIBUTES, THEMES.dotted, false);
     siteTuner.launchTuner();
 
     const commentText = 'Hello world!';

--- a/src/content_script/site_tuner.ts
+++ b/src/content_script/site_tuner.ts
@@ -365,10 +365,7 @@ export abstract class SiteTuner {
         wrapperComponent.setAttribute(WRAPPER_SCORES_ATTR, JSON.stringify(scores));
       });
     }
-    return scoringPromise.then(() => {
-      this.setCommentVisibility(
-        wrapperComponent, this.threshold, this.enabledAttributes, this.subtypesEnabled);
-    });
+    return scoringPromise.then(() => this.setCommentVisibility(wrapperComponent));
   }
 
   // When nodes are removed, we want to remove any customization we did to the
@@ -393,15 +390,14 @@ export abstract class SiteTuner {
   }
 
   // TODO: maybe we should move this logic into the wrapper components?
-  private setCommentVisibility(wrapperComponent: Element, threshold: number,
-                               enabledAttributes: EnabledAttributes, subtypesEnabled: boolean) {
+  private setCommentVisibility(wrapperComponent: Element) {
     const scores = safeParse(wrapperComponent.getAttribute(WRAPPER_SCORES_ATTR));
     if (scores === undefined) {
       console.error('BUG: invalid scores? skipping comment:', scores, wrapperComponent);
     }
 
     const commentVisibility: CommentVisibilityDecision = getCommentVisibility(
-      scores, threshold, enabledAttributes, subtypesEnabled);
+      scores, this.threshold, this.enabledAttributes, this.subtypesEnabled);
 
     if (commentVisibility.kind === 'showComment') {
       wrapperComponent.setAttribute(WRAPPER_TUNE_STATE_ATTR, TUNE_STATE.show);
@@ -507,8 +503,7 @@ export abstract class SiteTuner {
           return;
         }
         wrapperComponent.setAttribute(WRAPPER_SCORES_ATTR, scores);
-        this.setCommentVisibility(
-          wrapperComponent, this.threshold, this.enabledAttributes, this.subtypesEnabled);
+        this.setCommentVisibility(wrapperComponent);
       });
   }
 
@@ -520,7 +515,6 @@ export abstract class SiteTuner {
                 this.threshold, this.enabledAttributes, this.subtypesEnabled);
     document.body
       .querySelectorAll('.' + WRAPPER_CLASS + '[' + WRAPPER_SCORES_ATTR + ']')
-      .forEach(wrapper => this.setCommentVisibility(
-          wrapper, this.threshold, this.enabledAttributes, this.subtypesEnabled));
+      .forEach(wrapper => this.setCommentVisibility(wrapper));
   }
 }

--- a/src/content_script/site_tuner.ts
+++ b/src/content_script/site_tuner.ts
@@ -140,7 +140,6 @@ export abstract class SiteTuner {
   protected shouldHandleRemoveMutations = false;
 
   private tuneEnabled = true;
-  private subtypesEnabled = false;
   private observer: MutationObserver = null;
 
   // Function to go from elements returned by commentBlockSelector to the text
@@ -185,7 +184,8 @@ export abstract class SiteTuner {
 
   constructor(protected threshold: number,
               protected enabledAttributes: EnabledAttributes,
-              protected theme: ThemeType) {
+              protected theme: ThemeType,
+              protected subtypesEnabled: boolean) {
     // Note: we create this on initialization but it doesn't start working until
     // we call 'observe' later on.
     this.observer = new MutationObserver(mutations => {


### PR DESCRIPTION
`subtypesEnabled` was being initialized to false in `SiteTuner` and only being correctly set when the setting got changed. This initializes SiteTuner with the correct value.