### PR TITLE
Capitalize the "H" in "GitHub" on the About Page

### DIFF
--- a/src/app/about_page.component.html
+++ b/src/app/about_page.component.html
@@ -20,7 +20,7 @@
       (click)="openLink('https://perspectiveapi.com')">Perspective</a> to help
     you focus on what matters. Learn more about our work on
     <a class="border" href="https://github.com/conversationai"
-      (click)="openLink('https://github.com/conversationai')">Github</a> and
+      (click)="openLink('https://github.com/conversationai')">GitHub</a> and
     <a class="border" href="https://medium.com/the-false-positive"
       (click)="openLink('https://medium.com/the-false-positive')">Medium.</a>
   </div>


### PR DESCRIPTION
Hi folks 👋 

Thanks for this awesome work! I'm having a lot of fun trying out the extension. Just a quick PR to change "Github" to "GitHub" on the About page =]

Currently trying to figure out the business of signing the CLA, but wanted to get this up in the meantime. Thanks!