### PR TITLE
Show semi-opaque white background for dark mode

### DIFF
--- a/src/content_script/customElements/dotted_comment_wrapper.component.css
+++ b/src/content_script/customElements/dotted_comment_wrapper.component.css
@@ -44,11 +44,11 @@
 }
 
 :host[tune-state="show"] > .--tune-placeholder:hover {
-  background-color: #fff;
+  background-color: hsla(360, 100%, 100%, 0.5);
 }
 
 :host[tune-state="show"] > .--tune-placeholder.--tune-commentVisible {
-  background-color: #fff;
+  background-color: hsla(360, 100%, 100%, 0.5);
 }
 
 :host[tune-state="show"] > .--tune-placeholder > .--tune-hiddenCommentWrapper {

--- a/src/content_script/customElements/dotted_comment_wrapper.component.css
+++ b/src/content_script/customElements/dotted_comment_wrapper.component.css
@@ -43,14 +43,6 @@
   margin: 0;
 }
 
-:host[tune-state="show"] > .--tune-placeholder:hover {
-  background-color: hsla(360, 100%, 100%, 0.5);
-}
-
-:host[tune-state="show"] > .--tune-placeholder.--tune-commentVisible {
-  background-color: hsla(360, 100%, 100%, 0.5);
-}
-
 :host[tune-state="show"] > .--tune-placeholder > .--tune-hiddenCommentWrapper {
   opacity: 1;
 }


### PR DESCRIPTION
This is in response to issue #10 with Twitter and YouTube dark modes causing non-legible text on hover and on text show. 

As a suggestion, I used a semi-opaque white for background. In this way, white mode and dark mode show a highlight. I'm open to other UI style fixes.

before:
<img width="326" alt="Screen Shot 2019-10-05 at 8 44 17 PM" src="https://user-images.githubusercontent.com/5950956/66262999-eb553100-e7b0-11e9-9a70-8ba8c48056a3.png">

*legibility issue*
<img width="337" alt="Screen Shot 2019-10-05 at 8 44 06 PM" src="https://user-images.githubusercontent.com/5950956/66263000-ee502180-e7b0-11e9-8d8b-4ffd30627662.png">

after: 
<img width="385" alt="Screen Shot 2019-10-05 at 8 32 10 PM" src="https://user-images.githubusercontent.com/5950956/66262972-679b4480-e7b0-11e9-9531-99ed6bc250a1.png">
<img width="363" alt="Screen Shot 2019-10-05 at 8 32 01 PM" src="https://user-images.githubusercontent.com/5950956/66262974-6bc76200-e7b0-11e9-94f9-655ce5639cf9.png">


