### PR TITLE
Update travis config based on breaking change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache:
   npm: true
 before_install:
   - export CHROME_BIN=/usr/bin/google-chrome
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+services:
+  - xvfb
 script:
   - npm run lint
   - npm run build:all

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   npm: true
 before_install:
   - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
 services:
   - xvfb
 script:


### PR DESCRIPTION
Experienced build error on another branch #12. Saw breaking change https://benlimmer.com/2019/01/14/travis-ci-xvfb/

Based my change on https://stackoverflow.com/a/55674747/7491536 

Build error message via 
https://travis-ci.org/conversationai/perspective-viewership-extension/builds/595410114?utm_source=github_status&utm_medium=notification
```$ export CHROME_BIN=/usr/bin/google-chrome
before_install.2
0.00s$ export DISPLAY=:99.0
0.00s$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .```